### PR TITLE
Added context variable to match the alexa request key

### DIFF
--- a/flask_ask/__init__.py
+++ b/flask_ask/__init__.py
@@ -12,5 +12,6 @@ from .core import (
     request,
     session,
     version,
+    context,
     convert_errors
 )


### PR DESCRIPTION
The Alexa request body has a top level object called ‘context’ next to request, session, and version.  I added this as something that can be imported as well.  It’s especially important now because the session object is no longer included for AudioPlayer requests.

Reference: https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference