### PR TITLE
Adding API gateweay AWS lambda deployment note

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,8 @@ To install Flask-Ask::
 ---------------
 You can deploy using any WSGI compliant framework (uWSGI, Gunicorn). `To deploy on AWS Lambda, use Zappa <https://github.com/Miserlou/Zappa>`_.
 
+Note: When deploying to AWS Lambda with Zappa, make sure you point the Alexa skill to the HTTPS API gateway that Zappa creates.
+
 ☤ Thank You
 ------------
 Thanks for checking this library out! I hope you find it useful.


### PR DESCRIPTION
Since most tutorials out on the internet I've found never mentioned Zappa it may be helpful for future adopters to be made aware that they can't use the ARN with flask-ask when deploying to AWS.