### PR TITLE
Correctly calculate timestamp skew

### DIFF
--- a/flask_ask/verifier.py
+++ b/flask_ask/verifier.py
@@ -33,7 +33,7 @@ def verify_signature(cert, signature, signed_data):
 
 def verify_timestamp(timestamp):
     dt = datetime.utcnow() - timestamp.replace(tzinfo=None)
-    if dt.seconds > 150:
+    if abs(dt.total_seconds()) > 150:
         raise VerificationError("Timestamp verification failed")
 
 


### PR DESCRIPTION
A timedelta object only stores days, seconds, and milliseconds
internally. The seconds and milliseconds properties are always positive,
and negative values are stored by adding a positive number of seconds
or milliseconds to a negative number of days. As an example, a timedelta
of -1 seconds is stored as -1 days and 86399 seconds, and that 86399
seconds is what you're getting when you access the seconds propery.

The net result is that if your clock is a few seconds behind Alexa's
clock, timestamp verification will fail. The total_seconds() method
returns the total number of seconds in the timedelta object, which
is what we actually want.