### PR TITLE
Fix UnicodeEncodeError when creating responses

### DIFF
--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -244,7 +244,10 @@ def _copyattr(src, dest, attr, convert=None):
 
 def _output_speech(speech):
     try:
-        xmldoc = ElementTree.fromstring(speech)
+        etree_string = speech
+        if isinstance(etree_string, unicode):
+            etree_string = etree_string.encode('utf-8')
+        xmldoc = ElementTree.fromstring(etree_string)
         if xmldoc.tag == 'speak':
             return {'type': 'SSML', 'ssml': speech}
     except ElementTree.ParseError as e:
@@ -255,3 +258,4 @@ def _output_speech(speech):
 def _dbgdump(obj, indent=2, default=None, cls=None):
     msg = json.dumps(obj, indent=indent, default=default, cls=cls)
     logger.debug(msg)
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+from flask_ask import statement
+
+def test_statement_handles_unicode_input():
+    non_ascii_statement = statement(u'ÜÖÄ')


### PR DESCRIPTION
flask_ask uses xml.etree to find out if the response contains SSML. Because xml.etree internally only works on byte strings it raises an error if the implicit encoding to ascii doesn't work. To avoid that unicode strings are encoded to utf-8 before parsing with xml.etree