### PR TITLE
Fixed PlaybackFailed request handling

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -391,13 +391,14 @@ class Ask(object):
             return f
         return decorator
 
-    def on_playback_failed(self, mapping={'offset': 'offsetInMilliseconds', 'error': 'error', 'playerActivity': 'activity'}, convert={}, default={}):
+    def on_playback_failed(self, mapping={}, convert={}, default={}):
         """Decorator routes an AudioPlayer.PlaybackFailed Request to the wrapped function.
 
         This AudioPlayer Request sent when Alexa encounters an error when attempting to play a stream.
 
         The wrapped view function may accept parameters from the AudioPlayer Request.
         In addition to locale, requestId, timestamp, and type
+        
         PlayBackFailed Requests include:
             error - Contains error info under parameters type and message
 
@@ -406,14 +407,14 @@ class Ask(object):
             currentPlaybackState - Details about the playback activity occurring at the time of the error
                 Contains the following parameters:
 
-            token - represents the audio stream currently playing when the error occurred.
-                Note that this may be different from the value of the request.token property.
+                    token - represents the audio stream currently playing when the error occurred.
+                        Note that this may be different from the value of the request.token property.
 
-            offsetInMilliseconds - Position in stream when request was sent.
-                Not end of stream, often few ms after Play Directive offset.
-                This parameter is automatically mapped to 'offset' by default.
+                    offsetInMilliseconds - Position in stream when request was sent.
+                        Not end of stream, often few ms after Play Directive offset.
+                        This parameter is automatically mapped to 'offset' by default.
 
-            playerActivity - player state when the error occurred
+                    playerActivity - player state when the error occurred
         """
         def decorator(f):
             self._intent_view_funcs['AudioPlayer.PlaybackFailed'] = f

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -391,8 +391,8 @@ class Ask(object):
             return f
         return decorator
 
-    def on_playback_failed(self, mapping={}, convert={}, default={}):
-        """Decorator routes an AudioPlayer.PlaybackNearlyFinished Request to the wrapped function.
+    def on_playback_failed(self, mapping={'offset': 'offsetInMilliseconds', 'error': 'error', 'playerActivity': 'activity'}, convert={}, default={}):
+        """Decorator routes an AudioPlayer.PlaybackFailed Request to the wrapped function.
 
         This AudioPlayer Request sent when Alexa encounters an error when attempting to play a stream.
 
@@ -416,10 +416,10 @@ class Ask(object):
             playerActivity - player state when the error occurred
         """
         def decorator(f):
-            self._intent_view_funcs['AudioPlayer.PlaybackStarted'] = f
-            self._intent_mappings['AudioPlayer.PlaybackStarted'] = mapping
-            self._intent_converts['AudioPlayer.PlaybackStarted'] = convert
-            self._intent_defaults['AudioPlayer.PlaybackStarted'] = default
+            self._intent_view_funcs['AudioPlayer.PlaybackFailed'] = f
+            self._intent_mappings['AudioPlayer.PlaybackFailed'] = mapping
+            self._intent_converts['AudioPlayer.PlaybackFailed'] = convert
+            self._intent_defaults['AudioPlayer.PlaybackFailed'] = default
 
             @wraps(f)
             def wrapper(*args, **kwargs):
@@ -506,7 +506,7 @@ class Ask(object):
         fresh_stream = models._Field()
         fresh_stream.__dict__.update(self.current_stream.__dict__)  # keeps url attribute after stopping stream
         fresh_stream.__dict__.update(self._from_directive())
-        
+
         context_info = self._from_context()
         if context_info != None:
             fresh_stream.__dict__.update(context_info)


### PR DESCRIPTION
Fixes #99 
Basically corrected what I assume were some issues left from copying and pasting so that PlaybackFailed should now handle correctly. Tested with GeeMusic to ensure it is working. The error gives a json string but I wasn't sure what to do with it so I left it as is, and it can be parsed if necessary when people implement the on_playback_failed function.