### PR TITLE
Include a tutorial instead of an old Youtube video on the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Flask-Ask is a `Flask extension <http://flask.pocoo.org/extensions/>`_ that make
 
 * `Flask-Ask quickstart on Amazon's Developer Blog <https://developer.amazon.com/public/community/post/Tx14R0IYYGH3SKT/Flask-Ask-A-New-Python-Framework-for-Rapid-Alexa-Skills-Kit-Development>`_.
 * `Level Up with our Alexa Skills Kit Video Tutorial <https://alexatutorial.com/>`_
-* `Chat on Gitter.im <https://gitter.im/johnwheeler/flask-ask/>`_ 
+* `Chat on Gitter.im <https://gitter.im/johnwheeler/flask-ask/>`_
 
 The Basics
 ===============
@@ -57,7 +57,7 @@ above:
 .. code-block:: yaml
 
     hello: Hello, {{ firstname }}
-    
+
 Templates are stored in a file called `templates.yaml` located in the application root. Checkout the `Tidepooler example <https://github.com/johnwheeler/flask-ask/tree/master/samples/tidepooler>`_ to see why it makes sense to extract speech out of the code and into templates as the number of spoken phrases grow.
 
 Features
@@ -97,7 +97,7 @@ Deployment
 
 You can deploy using any WSGI compliant framework (uWSGI, Gunicorn). If you haven't deployed a Flask app to production, `checkout flask-live-starter <https://github.com/johnwheeler/flask-live-starter>`_.
 
-To deploy on AWS Lambda, use `Zappa <https://github.com/Miserlou/Zappa>`_. This `12-minute video <https://www.youtube.com/watch?v=mjWV4R2P4ks>`_ shows how to deploy Flask-Ask with Zappa from scratch.
+To deploy on AWS Lambda, use `Zappa <https://github.com/Miserlou/Zappa>`_. This `blog post <https://developer.amazon.com/blogs/post/8e8ad73a-99e9-4c0f-a7b3-60f92287b0bf/new-alexa-tutorial-deploy-flask-ask-skills-to-aws-lambda-with-zappa>`_ shows how to deploy Flask-Ask with Zappa from scratch.
 
 Note: When deploying to AWS Lambda with Zappa, make sure you point the Alexa skill to the HTTPS API gateway that Zappa creates, not the Lambda function's ARN.
 


### PR DESCRIPTION
I added the tutorial https://developer.amazon.com/blogs/post/8e8ad73a-99e9-4c0f-a7b3-60f92287b0bf/new-alexa-tutorial-deploy-flask-ask-skills-to-aws-lambda-with-zappa instead of an old Youtube video on the README.