### PR TITLE
Updated SessionEndedRequest handling related to Issue #115

### DIFF
--- a/docs/requests.rst
+++ b/docs/requests.rst
@@ -62,7 +62,7 @@ The ``session_ended`` decorator is for the session ended request::
 
     @ask.session_ended
     def session_ended():
-        return "", 200
+        return "{}", 200
 
 Launch and intent requests can both start sessions. Avoid duplicate code with the ``on_session_started`` callback::
 

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -183,7 +183,7 @@ class Ask(object):
 
         @ask.session_ended
         def session_ended():
-            return "", 200
+            return "{}", 200
 
         The wrapped function is registered as the session_ended view function
         and renders the response for requests to the end of the session.
@@ -398,7 +398,7 @@ class Ask(object):
 
         The wrapped view function may accept parameters from the AudioPlayer Request.
         In addition to locale, requestId, timestamp, and type
-        
+
         PlayBackFailed Requests include:
             error - Contains error info under parameters type and message
 
@@ -554,8 +554,11 @@ class Ask(object):
 
         if request_type == 'LaunchRequest' and self._launch_view_func:
             result = self._launch_view_func()
-        elif request_type == 'SessionEndedRequest' and self._session_ended_view_func:
-            result = self._session_ended_view_func()
+        elif request_type == 'SessionEndedRequest':
+            if self._session_ended_view_func:
+                result = self._session_ended_view_func()
+            else:
+                result = "{}", 200
         elif request_type == 'IntentRequest' and self._intent_view_funcs:
             result = self._map_intent_to_view_func(self.request.intent)()
         elif 'AudioPlayer' in request_type:

--- a/samples/audio/playlist_demo/playlist.py
+++ b/samples/audio/playlist_demo/playlist.py
@@ -232,7 +232,7 @@ def resume():
 
 @ask.session_ended
 def session_ended():
-    return "", 200
+    return "{}", 200
 
 def dump_stream_info():
     status = {

--- a/samples/audio/simple_demo/ask_audio.py
+++ b/samples/audio/simple_demo/ask_audio.py
@@ -72,7 +72,7 @@ def stream_finished(token):
 
 @ask.session_ended
 def session_ended():
-    return "", 200
+    return "{}", 200
 
 def _infodump(obj, indent=2):
     msg = json.dumps(obj, indent=indent)

--- a/samples/blueprint_demo/helloworld.py
+++ b/samples/blueprint_demo/helloworld.py
@@ -30,5 +30,5 @@ def help():
 
 @ask.session_ended
 def session_ended():
-    return "", 200
+    return "{}", 200
 

--- a/samples/helloworld/helloworld.py
+++ b/samples/helloworld/helloworld.py
@@ -29,7 +29,7 @@ def help():
 
 @ask.session_ended
 def session_ended():
-    return "", 200
+    return "{}", 200
 
 
 if __name__ == '__main__':

--- a/samples/historybuff/historybuff.py
+++ b/samples/historybuff/historybuff.py
@@ -99,7 +99,7 @@ def cancel():
 
 @ask.session_ended
 def session_ended():
-    return "", 200
+    return "{}", 200
 
 
 def _get_json_events_from_wikipedia(month, date):

--- a/samples/session/session.py
+++ b/samples/session/session.py
@@ -47,7 +47,7 @@ def whats_my_color():
 
 @ask.session_ended
 def session_ended():
-    return "", 200
+    return "{}", 200
 
 
 if __name__ == '__main__':

--- a/samples/spacegeek/spacegeek.py
+++ b/samples/spacegeek/spacegeek.py
@@ -44,7 +44,7 @@ def cancel():
 
 @ask.session_ended
 def session_ended():
-    return "", 200
+    return "{}", 200
 
 
 if __name__ == '__main__':

--- a/samples/tidepooler/tidepooler.py
+++ b/samples/tidepooler/tidepooler.py
@@ -136,7 +136,7 @@ def cancel():
 
 @ask.session_ended
 def session_ended():
-    return "", 200
+    return "{}", 200
 
 
 @app.template_filter()


### PR DESCRIPTION
Just happened to come across this issue in a skill I was developing and noticed someone had just opened #115.

Amazon expects an HTTP 200 response with `{}` as the body when it sends a `SessionEndedRequest`. One example of this is when the user says nothing during a session and Alexa times out. 

If you return the empty string literal `""` as currently shown in examples and documentation, Amazon gets very upset. This prevents skills from passing the submission screening process.

The changes I'm proposing update all examples to show the proper response (since it's not well documented by Amazon) and also add the default behavior for an Ask app to send the correct response when given a `SessionEndedRequest`. This should help uses of Flask-Ask not fall into this headache-inducing trap in the future.