### PR TITLE
Added new card type: consent_card

### DIFF
--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -84,6 +84,14 @@ class _Response(object):
         card = {'type': 'LinkAccount'}
         self._response['card'] = card
         return self
+        
+    def consent_card(self, permissions):
+        card = {
+            'type': 'AskForPermissionsConsent',
+            'permissions': [permissions]
+        }
+        self._response['card'] = card
+        return sel
 
     def render_response(self):
         response_wrapper = {

--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -91,7 +91,7 @@ class _Response(object):
             'permissions': [permissions]
         }
         self._response['card'] = card
-        return sel
+        return self
 
     def render_response(self):
         response_wrapper = {


### PR DESCRIPTION
There is a new type of card AskForPermissionsConsentCard. You can ask for the permission to retrieve the device location with it. See: https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api#permissions-card
Permissions can be either read::alexa:device:all:address or read::alexa:device:all:address:country_and_postal_code