### PR TITLE
Issue 126 - Resolving HTTP 500 when no Context is present

### DIFF
--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -221,7 +221,7 @@ class audio(_Response):
             if context:
                 key = context.get('System', {}).get('user', {}).get('userId', ANONYMOUS_KEY)
             else:
-                logger.warning('Anonymous key being used due to missing Context.')
+                logger.warning('Anonymous key being used due to missing Context!')
                 key = ANONYMOUS_KEY
 
             push_stream(stream_cache, key, stream)

--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -10,6 +10,11 @@ import uuid
 from pprint import pprint
 
 
+# Only use the anonymous key if you're not concerened
+# about multiple users or workers trampling one another
+ANONYMOUS_KEY = 'anonymous'
+
+
 class _Field(dict):
     """Container to represent Alexa Request Data.
 
@@ -213,7 +218,13 @@ class audio(_Response):
             stream['offsetInMilliseconds'] = offset
 
         if push_buffer:  # prevents enqueued streams from becoming current_stream
-            push_stream(stream_cache, context['System']['user']['userId'], stream)
+            if context:
+                key = context.get('System', {}).get('user', {}).get('userId', ANONYMOUS_KEY)
+            else:
+                logger.warning('Anonymous key being used due to missing Context.')
+                key = ANONYMOUS_KEY
+
+            push_stream(stream_cache, key, stream)
         return audio_item
 
     def stop(self):

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,6 +1,5 @@
 import unittest
 from mock import patch, MagicMock
-from flask import Flask
 from flask_ask import Ask, audio
 from flask_ask.models import _Field
 
@@ -10,18 +9,23 @@ class AudioUnitTests(unittest.TestCase):
     def setUp(self):
         self.ask_patcher = patch('flask_ask.core.find_ask', return_value=Ask())
         self.ask_patcher.start()
-        self.context_patcher = patch('flask_ask.models.context', return_value=MagicMock())
-        self.context_patcher.start()
 
     def tearDown(self):
         self.ask_patcher.stop()
-        self.context_patcher.stop()
 
-    def test_token_generation(self):
+    @patch('flask_ask.models.context', return_value=MagicMock())
+    def test_token_generation(self, mock_context):
         """ Confirm we get a new token when setting a stream url """
         audio_item = audio()._audio_item(stream_url='https://fakestream', offset=123)
         self.assertEqual(36, len(audio_item['stream']['token']))
         self.assertEqual(123, audio_item['stream']['offsetInMilliseconds'])
+
+    def test_audio_item_without_context(self):
+        try:
+            a = audio()
+            self.assertIsNotNone(a._audio_item(stream_url='https://fakestream'))
+        except:
+            self.fail('should not raise exception')
 
 
 class AskStreamHandlingTests(unittest.TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -84,6 +84,13 @@ class AudioIntegrationTests(unittest.TestCase):
         self.assertEqual(self.stream_url, stream['url'])
         self.assertEqual(0, stream['offsetInMilliseconds'])
 
+    def test_play_without_context(self):
+        """ Test if we can play even without a Context being provided. """
+        request = play_request.copy()
+        del request['context']
+        response = self.client.post('/ask', data=json.dumps(request))
+        self.assertEqual(200, response.status_code)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Here's a potential solution to how we can handle Context-less requests, like those currently generated by the Alexa web-based service simulator provided by Amazon. 

I'm a bit torn about this approach as in practice a skill should never receive a request without a context (and userId), but it seems Amazon encourages manual testing without contexts.

This change does the following:
1. The change uses a common key (`models.ANONYMOUS_KEY`) that will be used any time there's no request. Since we can't identify the user (i.e. no context), we will still support using the audio cache appropriately.
2. When a context isn't present, the `models.audio._audio_item()` method will generate a warning log message reminding a manual tester, developer, or admin that something isn't quite right.
3. Adds some tests to make sure we can handle building an `audio` object/response without context, including using one of the audio sample projects to make sure it works in a fully integrated fashion.

There should be no production side-effects as, once again, Amazon insists the context will always be present.