### PR TITLE
Print debug output in minified form unless otherwise specified

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -34,7 +34,7 @@ def find_ask():
 
 
 def _dbgdump(obj, default=None, cls=None):
-    if current_app.config['ASK_PRETTY_DEBUG_LOGS']:
+    if current_app.config.get('ASK_PRETTY_DEBUG_LOGS', False):
         indent = 2
     else:
         indent = None

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -115,11 +115,10 @@ class Ask(object):
             being synchronized with an NTP server. This setting should not be enabled in production.
             Default: False
 
-        `ASK_MINIFY_DEBUG_LOGS`:
+        `ASK_PRETTY_DEBUG_LOGS`:
 
-            Turn on to print debug-level logs of the request and response in minified form instead of pretty-printing.
-            This is useful when debug logs are sent to CloudWatch, which prettifies JSON natively and breaks
-            already-prettified JSON objects into multiple events.
+            Add tabs and linebreaks to the Alexa request and response printed to the debug log.
+            This improves readability when printing to the console, but breaks formatting when logging to CloudWatch.
             Default: False
         """
         if self._route is None:
@@ -164,7 +163,7 @@ class Ask(object):
         return current_app.config.get('ASK_APPLICATION_ID', None)
 
     @property
-    def ask_minify_debug_logs(self):
+    def ask_pretty_debug_logs(self):
         return current_app.config.get('ASK_MINIFY_DEBUG_LOGS', False)
 
     def on_session_started(self, f):
@@ -590,7 +589,7 @@ class Ask(object):
             fresh_stream.__dict__.update(context_info)
 
         self.current_stream = fresh_stream
-        _dbgdump(current_stream.__dict__, indent=None if self.ask_minify_debug_logs else 2)
+        _dbgdump(current_stream.__dict__, indent=2 if self.ask_pretty_debug_logs else None)
 
     def _from_context(self):
         return getattr(self.context, 'AudioPlayer', {})
@@ -605,7 +604,7 @@ class Ask(object):
 
     def _flask_view_func(self, *args, **kwargs):
         ask_payload = self._alexa_request(verify=self.ask_verify_requests)
-        _dbgdump(ask_payload, indent=None if self.ask_minify_debug_logs else 2)
+        _dbgdump(ask_payload, indent=2 if self.ask_pretty_debug_logs else None)
         request_body = models._Field(ask_payload)
 
         self.request = request_body.request
@@ -745,6 +744,6 @@ class YamlLoader(BaseLoader):
         return TemplateNotFound(template)
 
 
-def _dbgdump(obj, indent=2, default=None, cls=None):
+def _dbgdump(obj, indent=None, default=None, cls=None):
     msg = json.dumps(obj, indent=indent, default=default, cls=cls)
     logger.debug(msg)

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -33,6 +33,10 @@ def find_ask():
                     return getattr(blueprints[blueprint_name], 'ask')
 
 
+def _dbgdump(obj, indent=None, default=None, cls=None):
+    msg = json.dumps(obj, indent=indent, default=default, cls=cls)
+    logger.debug(msg)
+
 
 request = LocalProxy(lambda: find_ask().request)
 session = LocalProxy(lambda: find_ask().session)
@@ -742,8 +746,3 @@ class YamlLoader(BaseLoader):
             source = self.mapping[template]
             return source, None, lambda: source == self.mapping.get(template)
         return TemplateNotFound(template)
-
-
-def _dbgdump(obj, indent=None, default=None, cls=None):
-    msg = json.dumps(obj, indent=indent, default=default, cls=cls)
-    logger.debug(msg)

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -108,7 +108,7 @@ class Ask(object):
             It is useful for mocking JSON requests in automated tests.
             Default: True
 
-        ASK_VERIFY_TIMESTAMP_DEBUG:
+        `ASK_VERIFY_TIMESTAMP_DEBUG`:
 
             Turn on request timestamp verification while debugging by setting this to True.
             Timestamp verification helps mitigate against replay attacks. It relies on the system clock

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -164,7 +164,7 @@ class Ask(object):
 
     @property
     def ask_pretty_debug_logs(self):
-        return current_app.config.get('ASK_MINIFY_DEBUG_LOGS', False)
+        return current_app.config.get('ASK_PRETTY_DEBUG_LOGS', False)
 
     def on_session_started(self, f):
         """Decorator to call wrapped function upon starting a session.

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -33,7 +33,11 @@ def find_ask():
                     return getattr(blueprints[blueprint_name], 'ask')
 
 
-def _dbgdump(obj, indent=None, default=None, cls=None):
+def _dbgdump(obj, default=None, cls=None):
+    if current_app.config['ASK_PRETTY_DEBUG_LOGS']:
+        indent = 2
+    else:
+        indent = None
     msg = json.dumps(obj, indent=indent, default=default, cls=cls)
     logger.debug(msg)
 
@@ -165,10 +169,6 @@ class Ask(object):
     @property
     def ask_application_id(self):
         return current_app.config.get('ASK_APPLICATION_ID', None)
-
-    @property
-    def ask_pretty_debug_logs(self):
-        return current_app.config.get('ASK_PRETTY_DEBUG_LOGS', False)
 
     def on_session_started(self, f):
         """Decorator to call wrapped function upon starting a session.
@@ -593,7 +593,7 @@ class Ask(object):
             fresh_stream.__dict__.update(context_info)
 
         self.current_stream = fresh_stream
-        _dbgdump(current_stream.__dict__, indent=2 if self.ask_pretty_debug_logs else None)
+        _dbgdump(current_stream.__dict__)
 
     def _from_context(self):
         return getattr(self.context, 'AudioPlayer', {})
@@ -608,7 +608,7 @@ class Ask(object):
 
     def _flask_view_func(self, *args, **kwargs):
         ask_payload = self._alexa_request(verify=self.ask_verify_requests)
-        _dbgdump(ask_payload, indent=2 if self.ask_pretty_debug_logs else None)
+        _dbgdump(ask_payload)
         request_body = models._Field(ask_payload)
 
         self.request = request_body.request

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -114,6 +114,13 @@ class Ask(object):
             Timestamp verification helps mitigate against replay attacks. It relies on the system clock
             being synchronized with an NTP server. This setting should not be enabled in production.
             Default: False
+
+        `ASK_MINIFY_DEBUG_LOGS`:
+
+            Turn on to print debug-level logs of the request and response in minified form instead of pretty-printing.
+            This is useful when debug logs are sent to CloudWatch, which prettifies JSON natively and breaks
+            already-prettified JSON objects into multiple events.
+            Default: False
         """
         if self._route is None:
             raise TypeError("route is a required argument when app is not None")
@@ -155,6 +162,10 @@ class Ask(object):
     @property
     def ask_application_id(self):
         return current_app.config.get('ASK_APPLICATION_ID', None)
+
+    @property
+    def ask_minify_debug_logs(self):
+        return current_app.config.get('ASK_MINIFY_DEBUG_LOGS', False)
 
     def on_session_started(self, f):
         """Decorator to call wrapped function upon starting a session.

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -590,7 +590,7 @@ class Ask(object):
             fresh_stream.__dict__.update(context_info)
 
         self.current_stream = fresh_stream
-        _dbgdump(current_stream.__dict__)
+        _dbgdump(current_stream.__dict__, indent=None if self.ask_minify_debug_logs else 2)
 
     def _from_context(self):
         return getattr(self.context, 'AudioPlayer', {})
@@ -605,7 +605,7 @@ class Ask(object):
 
     def _flask_view_func(self, *args, **kwargs):
         ask_payload = self._alexa_request(verify=self.ask_verify_requests)
-        _dbgdump(ask_payload)
+        _dbgdump(ask_payload, indent=None if self.ask_minify_debug_logs else 2)
         request_body = models._Field(ask_payload)
 
         self.request = request_body.request

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -33,7 +33,7 @@ def find_ask():
                     return getattr(blueprints[blueprint_name], 'ask')
 
 
-def _dbgdump(obj, default=None, cls=None):
+def dbgdump(obj, default=None, cls=None):
     if current_app.config.get('ASK_PRETTY_DEBUG_LOGS', False):
         indent = 2
     else:
@@ -593,7 +593,7 @@ class Ask(object):
             fresh_stream.__dict__.update(context_info)
 
         self.current_stream = fresh_stream
-        _dbgdump(current_stream.__dict__)
+        dbgdump(current_stream.__dict__)
 
     def _from_context(self):
         return getattr(self.context, 'AudioPlayer', {})
@@ -608,7 +608,7 @@ class Ask(object):
 
     def _flask_view_func(self, *args, **kwargs):
         ask_payload = self._alexa_request(verify=self.ask_verify_requests)
-        _dbgdump(ask_payload)
+        dbgdump(ask_payload)
         request_body = models._Field(ask_payload)
 
         self.request = request_body.request

--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -1,5 +1,5 @@
 import inspect
-from flask import json, current_app
+from flask import json
 from xml.etree import ElementTree
 import aniso8601
 from .core import session, context, current_stream, stream_cache, dbgdump
@@ -106,8 +106,7 @@ class _Response(object):
             kw[kwargname] = json_encoder
         dbgdump(response_wrapper, **kw)
 
-        return json.dumps(response_wrapper,
-                          indent=2 if current_app.config.get('ASK_MINIFY_DEBUG_LOGS', False) else None, **kw)
+        return json.dumps(response_wrapper, **kw)
 
 
 class statement(_Response):

--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -260,6 +260,6 @@ def _output_speech(speech):
     return {'type': 'PlainText', 'text': speech}
 
 
-def _dbgdump(obj, indent=2, default=None, cls=None):
+def _dbgdump(obj, indent=None, default=None, cls=None):
     msg = json.dumps(obj, indent=indent, default=default, cls=cls)
     logger.debug(msg)

--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -1,5 +1,5 @@
 import inspect
-from flask import json
+from flask import json, current_app
 from xml.etree import ElementTree
 import aniso8601
 from .core import session, context, current_stream, stream_cache
@@ -106,7 +106,8 @@ class _Response(object):
             kw[kwargname] = json_encoder
         _dbgdump(response_wrapper, **kw)
 
-        return json.dumps(response_wrapper, **kw)
+        return json.dumps(response_wrapper,
+                          indent=2 if current_app.config.get('ASK_MINIFY_DEBUG_LOGS', False) else None, **kw)
 
 
 class statement(_Response):

--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -2,7 +2,7 @@ import inspect
 from flask import json, current_app
 from xml.etree import ElementTree
 import aniso8601
-from .core import session, context, current_stream, stream_cache, _dbgdump
+from .core import session, context, current_stream, stream_cache, dbgdump
 from .cache import push_stream
 from . import logger
 import uuid
@@ -104,7 +104,7 @@ class _Response(object):
             json_encoder = session.attributes_encoder
             kwargname = 'cls' if inspect.isclass(json_encoder) else 'default'
             kw[kwargname] = json_encoder
-        _dbgdump(response_wrapper, **kw)
+        dbgdump(response_wrapper, **kw)
 
         return json.dumps(response_wrapper,
                           indent=2 if current_app.config.get('ASK_MINIFY_DEBUG_LOGS', False) else None, **kw)

--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -2,7 +2,7 @@ import inspect
 from flask import json, current_app
 from xml.etree import ElementTree
 import aniso8601
-from .core import session, context, current_stream, stream_cache
+from .core import session, context, current_stream, stream_cache, _dbgdump
 from .cache import push_stream
 from . import logger
 import uuid
@@ -258,8 +258,3 @@ def _output_speech(speech):
     except (UnicodeEncodeError, ElementTree.ParseError) as e:
         pass
     return {'type': 'PlainText', 'text': speech}
-
-
-def _dbgdump(obj, indent=None, default=None, cls=None):
-    msg = json.dumps(obj, indent=indent, default=default, cls=cls)
-    logger.debug(msg)


### PR DESCRIPTION
This adds a config variable `ASK_MINIFY_DEBUG_LOGS` which, if set to True, minifies the request and response JSON dumps printed to the debug log. Default value is False.

This is useful when logging to CloudWatch, as it prevents the output from being broken up into multiple log events. CloudWatch automatically prettifies single-line JSON objects, and splits multi-line ones into one event per line.