### PR TITLE
Support custom opaque tokens

### DIFF
--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch, MagicMock
 from flask import Flask
 from flask_ask import Ask, audio
-from flask_ask.models import _Field
+from flask_ask.models import _Field, _Response
 
 
 class AudioUnitTests(unittest.TestCase):
@@ -26,9 +26,9 @@ class AudioUnitTests(unittest.TestCase):
     def test_custom_token(self):
         """ Check to see that the provided opaque token remains constant"""
         token = "hello_world"
-        audio_item = audio().play(stream_url='https://fakestream', offset=10, opaque_token=token)
+        audio_item = audio()._audio_item(stream_url='https://fakestream', offset=10, opaque_token=token)
         self.assertEqual(token, audio_item['stream']['token'])
-        self.assertEqual(-99, audio_item['stream']['offsetInMilliseconds'])
+        self.assertEqual(10, audio_item['stream']['offsetInMilliseconds'])
 
 
 class AskStreamHandlingTests(unittest.TestCase):
@@ -61,7 +61,6 @@ class AskStreamHandlingTests(unittest.TestCase):
         with patch('flask_ask.core.top_stream', return_value=fake_stream):
             from_buffer = ask._from_directive()
             self.assertEqual(fake_stream, from_buffer)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -2,7 +2,7 @@ import unittest
 from mock import patch, MagicMock
 from flask import Flask
 from flask_ask import Ask, audio
-from flask_ask.models import _Field, _Response
+from flask_ask.models import _Field
 
 
 class AudioUnitTests(unittest.TestCase):
@@ -61,6 +61,7 @@ class AskStreamHandlingTests(unittest.TestCase):
         with patch('flask_ask.core.top_stream', return_value=fake_stream):
             from_buffer = ask._from_directive()
             self.assertEqual(fake_stream, from_buffer)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -23,6 +23,13 @@ class AudioUnitTests(unittest.TestCase):
         self.assertEqual(36, len(audio_item['stream']['token']))
         self.assertEqual(123, audio_item['stream']['offsetInMilliseconds'])
 
+    def test_custom_token(self):
+        """ Check to see that the provided opaque token remains constant"""
+        token = "hello_world"
+        audio_item = audio().play(stream_url='https://fakestream', offset=10, opaque_token=token)
+        self.assertEqual(token, audio_item['stream']['token'])
+        self.assertEqual(-99, audio_item['stream']['offsetInMilliseconds'])
+
 
 class AskStreamHandlingTests(unittest.TestCase):
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,7 @@
 import unittest
 import json
+import uuid
+
 from flask_ask import Ask, audio
 from flask import Flask
 
@@ -59,10 +61,16 @@ class AudioIntegrationTests(unittest.TestCase):
         self.ask = Ask(app=self.app, route='/ask')
         self.client = self.app.test_client()
         self.stream_url = 'https://fakestream'
+        self.custom_token = 'custom_uuid_{0}'.format(str(uuid.uuid4()))
 
         @self.ask.intent('TestPlay')
         def play():
             return audio('playing').play(self.stream_url)
+
+        @self.ask.intent('TestCustomTokenIntents')
+        def custom_token_intents():
+            return audio('playing with custom token').play(self.stream_url, 
+                                                           opaque_token=self.custom_token)
 
     def tearDown(self):
         pass
@@ -83,6 +91,31 @@ class AudioIntegrationTests(unittest.TestCase):
         self.assertIsNotNone(stream['token'])
         self.assertEqual(self.stream_url, stream['url'])
         self.assertEqual(0, stream['offsetInMilliseconds'])
+
+    def test_play_intent_with_custom_token(self):
+        """ Test to check that custom token supplied is returned """
+
+        # change the intent name to route to our custom token for play_request
+        original_intent_name = play_request['request']['intent']['name']
+        play_request['request']['intent']['name'] = 'TestCustomTokenIntents'
+
+        response = self.client.post('/ask', data=json.dumps(play_request))
+        self.assertEqual(200, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual('playing with custom token',
+                         data['response']['outputSpeech']['text'])
+
+        directive = data['response']['directives'][0]
+        self.assertEqual('AudioPlayer.Play', directive['type'])
+
+        stream = directive['audioItem']['stream']
+        self.assertEqual(stream['token'], self.custom_token)
+        self.assertEqual(self.stream_url, stream['url'])
+        self.assertEqual(0, stream['offsetInMilliseconds'])
+
+        # reset our play_request
+        play_request['request']['intent']['name'] = original_intent_name
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Issue: johnwheeler/flask-ask/issues/174

This PR allows custom tokens to be set for `play`, `enqueue`, and `play_next`.