### PR TITLE
fix for YamlLoader: raise TemplateNotFound instead of returning it

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -871,4 +871,4 @@ class YamlLoader(BaseLoader):
         if template in self.mapping:
             source = self.mapping[template]
             return source, None, lambda: source == self.mapping.get(template)
-        return TemplateNotFound(template)
+        raise TemplateNotFound(template)


### PR DESCRIPTION
makes `YamlLoader` return, instead of raising, `TemplateNotFound`

according to the [Jinja2 documentation](http://jinja.pocoo.org/docs/2.10/api/#jinja2.BaseLoader.get_source) for `get_source`: _[...] has to return a tuple [...] or **raise** a TemplateNotFound [...]_

using `return TemplateNotFound` (as it's done now) will conflict with other Flask extensions that use templates (for instance, [Flask-Admin](https://github.com/flask-admin/flask-admin)).