### PR TITLE
Support for Custom Slots added

### DIFF
--- a/samples/slotDemo/SlotDemo.py
+++ b/samples/slotDemo/SlotDemo.py
@@ -1,0 +1,49 @@
+import logging
+import os
+
+from flask import Flask
+from flask_ask import Ask, request, session, question, statement
+
+
+app = Flask(__name__)
+app.debug = True
+
+ask = Ask(app, "/")
+logging.getLogger('flask_ask').setLevel(logging.DEBUG)
+
+
+@ask.launch
+def launch():
+    speech_text = 'Welcome to the Flask Ask Slot demonstration.' + \
+                  'You can ask me to add things to slots; for example ' + \
+                  'add battle cat and megatron and top cat'
+    return question(speech_text).reprompt(speech_text).simple_card('Flask Ask Slot Demo', speech_text)
+
+
+def parse_slot(slot):
+    if (slot is None):
+        return "slot wasn't specified. "
+
+    speech_text = 'slot has value ' + slot.value
+    if str(slot.code) == 'ER_SUCCESS_MATCH':
+        speech_text += ' and matched with id ' + str(slot.id)
+        speech_text += ' and name ' + str(slot.name)
+    else:
+        speech_text += ' but had no match'
+    speech_text += '. '
+    return speech_text
+
+@ask.intent('FlaskAskSlotTest', types={'first':'slot','second':'slot'})
+def slot_test(first, second, third):
+    speech_text  = 'First ' + parse_slot(first)
+    speech_text += 'Second ' + parse_slot(second)
+    speech_text += 'Third value is ' + str(third)
+    return statement(speech_text).simple_card('Flask Ask Slot Demo', speech_text)
+
+
+if __name__ == '__main__':
+    if 'ASK_VERIFY_REQUESTS' in os.environ:
+        verify = str(os.environ.get('ASK_VERIFY_REQUESTS', '')).lower()
+        if verify == 'false':
+            app.config['ASK_VERIFY_REQUESTS'] = False
+    app.run(debug=True, port=4010)

--- a/samples/slotDemo/speech_assets/model.json
+++ b/samples/slotDemo/speech_assets/model.json
@@ -1,0 +1,81 @@
+{
+  "languageModel": {
+    "types": [
+      {
+        "name": "slot_list",
+        "values": [
+          {
+            "id": "SLOT_TRANSFORMERS",
+            "name": {
+              "value": "transformer",
+              "synonyms": [
+                "Optimus Prime",
+                "Bumblebee",
+                "Megatron"
+              ]
+            }
+          },
+          {
+            "id": "SLOT_HEMAN",
+            "name": {
+              "value": "He Man",
+              "synonyms": [
+                "Man At Arms",
+                "Battle Cat"
+              ]
+            }
+          },
+          {
+            "id": "SLOT_DD",
+            "name": {
+              "value": "Dungeons and Dragons",
+              "synonyms": [
+                "Eric",
+                "Presto",
+                "Dungeon Master"
+              ]
+            }
+          }
+        ]
+      }
+    ],
+    "intents": [
+      {
+        "name": "AMAZON.CancelIntent",
+        "samples": []
+      },
+      {
+        "name": "AMAZON.HelpIntent",
+        "samples": []
+      },
+      {
+        "name": "AMAZON.StopIntent",
+        "samples": []
+      },
+      {
+        "name": "FlaskAskSlotTest",
+        "samples": [
+          "add {first} and {second}",
+          "add {first}",
+          "add {first} and {second} and {third}"
+        ],
+        "slots": [
+          {
+            "name": "first",
+            "type": "slot_list"
+          },
+          {
+            "name": "second",
+            "type": "slot_list"
+          },
+          {
+            "name": "third",
+            "type": "slot_list"
+          }
+        ]
+      }
+    ],
+    "invocationName": "flask slot demo"
+  }
+}
+


### PR DESCRIPTION
By using a new 'types' map when defining an intent it's possible to request the set of custom slot values for a given value. Without the types map the original behavior is maintained.

A new example is also added that demonstrates this behaviour

I'm not a python coder, so there may be tidier ways of doing bits of this! However it does all seem to work and has been tested by driving the example code in various 'unhappy path' ways.