### PR TITLE
Use io.StringIO in place of StringIO. As per recommendation from Pyth…

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -3,7 +3,7 @@ import sys
 import yaml
 import inspect
 from datetime import datetime
-from StringIO import StringIO
+from io import StringIO
 from functools import wraps, partial
 
 import aniso8601


### PR DESCRIPTION
As per recommendation from Python 3.0 changelog (https://docs.python.org/3.0/whatsnew/3.0.html) use io.StringIO in place of StringIO.

io.StringIO is available in both Python 2.7 and 3.6.

Impetus for this change is that I started receiving the following error after upgrading from Flask-Ask 0.9.6.
```
  File "/var/task/flask_ask/core.py", line 6, in <module>
  from StringIO import StringIO
ModuleNotFoundError: No module named 'StringIO'
```