### PR TITLE
Upgrade six

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ aniso8601==1.2.0
 Flask==0.12.1
 pyOpenSSL==17.0.0
 PyYAML==3.12
-six==1.10.0
+six==1.11.0
 


### PR DESCRIPTION
I'm new to Alexa development (as we all are I suppose), but have found [`zappa`](https://github.com/Miserlou/Zappa/) to be an essential tool in deploying/managing this sort of project.

Problem is, zappa requires `six>=1.11.0`, and your requirements specify `six==1.10.0`.

I've made the upgrade in my fork and ran the unit tests without issue. So maybe freezing six at 1.10 isn't necessary?

BTW...Thanks for sharing this awesome project. As someone who prefers Python to Javascript, it has been quite helpful to me.