### PR TITLE
Modified StringIO import to support Python 3

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -3,7 +3,11 @@ import sys
 import yaml
 import inspect
 from datetime import datetime
-from StringIO import StringIO
+# Needed to support Python 3
+try:
+    from StringIO import StringIO
+except ModuleNotFoundError:
+    from io import StringIO
 from functools import wraps, partial
 
 import aniso8601


### PR DESCRIPTION
The StringIO module was removed in Python 3. I encountered an error while running this code. Using [this](https://stackoverflow.com/questions/11914472/stringio-in-python3) StackOverflow post, I added a backup import to be used in Python 3.