### PR TITLE
Fix for using <amazon:effect> SSML

### DIFF
--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -1,6 +1,6 @@
 import inspect
 from flask import json
-from xml.etree import ElementTree
+from lxml import etree
 import aniso8601
 from .core import session, context, current_stream, stream_cache, dbgdump
 from .cache import push_stream
@@ -399,9 +399,10 @@ def _copyattr(src, dest, attr, convert=None):
 
 def _output_speech(speech):
     try:
-        xmldoc = ElementTree.fromstring(speech)
+        parser = etree.XMLParser(dtd_validation=False, load_dtd=False, recover=True)
+        xmldoc = etree.fromstring(speech, parser)
         if xmldoc.tag == 'speak':
             return {'type': 'SSML', 'ssml': speech}
-    except (UnicodeEncodeError, ElementTree.ParseError) as e:
+    except (UnicodeEncodeError, etree.ParseError) as e:
         pass
     return {'type': 'PlainText', 'text': speech}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ Flask==0.12.1
 pyOpenSSL==17.0.0
 PyYAML==3.12
 six==1.11.0
+lxml==4.1.1
 


### PR DESCRIPTION
Encountered an issue where if I tried to submit a template with the <amazon:effect> tag, the parser would raise an error. This would result in the SSML being submitted as plain text. 

I've moved from using xml.etree to lxml, which seems to solve the problem, but does add another dependency.