### PR TITLE
Implement list_templates in YamlLoader

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -872,3 +872,6 @@ class YamlLoader(BaseLoader):
             source = self.mapping[template]
             return source, None, lambda: source == self.mapping.get(template)
         raise TemplateNotFound(template)
+
+    def load_templates(self):
+        return sorted(self.mapping)

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -873,5 +873,5 @@ class YamlLoader(BaseLoader):
             return source, None, lambda: source == self.mapping.get(template)
         raise TemplateNotFound(template)
 
-    def load_templates(self):
+    def list_templates(self):
         return sorted(self.mapping)


### PR DESCRIPTION
This allows listing all templates from the Jinja environment with
`app.jinja_env.list_templates()`, which can be helpful during debugging.
See here for the an official documentation:
http://jinja.pocoo.org/docs/2.10/api/#jinja2.Environment.list_templates

list_templates is a method of BaseLoader which must be overwritten
by subclasses, see Jinjas default loaders for examples:
https://github.com/pallets/jinja/blob/master/jinja2/loaders.py