### PR TITLE
Make YamlLoader accept absolute paths

### DIFF
--- a/docs/responses.rst
+++ b/docs/responses.rst
@@ -144,3 +144,5 @@ You can also use Jinja templates. Define them in a YAML file named `templates.ya
 You can also use a custom templates file passed into the Ask object::
 
   ask = Ask(app, '/', None, 'custom-templates.yml')
+
+The path may be an absolute or relative path.

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -853,7 +853,10 @@ class Ask(object):
 class YamlLoader(BaseLoader):
 
     def __init__(self, app, path):
-        self.path = app.root_path + os.path.sep + path
+        if os.path.isabs(path):
+            self.path = path
+        else:
+            self.path = app.root_path + os.path.sep + path
         self.mapping = {}
         self._reload_mapping()
 

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -72,7 +72,7 @@ class Ask(object):
         route {str} -- entry point to which initial Alexa Requests are forwarded (default: {None})
         blueprint {Flask blueprint} -- Flask Blueprint instance to use instead of Flask App (default: {None})
         stream_cache {Werkzeug BasicCache} -- BasicCache-like object for storing Audio stream data (default: {SimpleCache})
-        path {str} -- path to templates yaml file for VUI dialog (default: {'templates.yaml'})
+        path {str} -- absolute or relative path to templates yaml file for VUI dialog (default: {'templates.yaml'})
     """
 
     def __init__(self, app=None, route=None, blueprint=None, stream_cache=None, path='templates.yaml'):


### PR DESCRIPTION
It would in some circumstances be useful if the YamlLoaders \_\_init__
could handle an absolute path to the templates file, such as when working
with pkg_resources. This implements that functionality with a quick
os.path.isabs check, without affecting any of the current default
settings.