### PR TITLE
pip 10 support and backward compatibility for pip <= 9.0.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,10 @@ Flask-Ask
 Easy Alexa Skills Kit integration for Flask
 """
 from setuptools import setup
-from pip.req import parse_requirements
+try:  # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError:  # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 setup(
     name='Flask-Ask',


### PR DESCRIPTION
Pip 10 support and backward compatibility for pip <= 9.0.3

To prevent the error : 

```
from pip.req import parse_requirements
ImportError: No module named req
```

Reference: 
https://stackoverflow.com/questions/49837301/pip-10-no-module-named-pip-req
