### PR TITLE
Fix problem with cryptography package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aniso8601==1.2.0
 Flask==0.12.1
+cryptography==2.1.4
 pyOpenSSL==17.0.0
 PyYAML==3.12
 six==1.11.0


### PR DESCRIPTION
In cryptography >= 2.2, there is an issue:
```
[1521581897750] File "/private/var/folders/8g/t93g7k9j0rb_18d07m1k8shr0000gn/T/pip-build-SO5htj/pyOpenSSL/OpenSSL/crypto.py", line 740, in _subjectAltNameString
[1521581897750] AttributeError: 'module' object has no attribute 'X509V3_EXT_get'
```
This will fix the issue.