### PR TITLE
Fixed broken video URLS in documentation

### DIFF
--- a/docs/requests.rst
+++ b/docs/requests.rst
@@ -41,8 +41,7 @@ This section shows how to process Alexa requests with Flask-Ask. It contains the
 Mapping Alexa Requests to View Functions
 ----------------------------------------
 
-📼 A `Handling Requests with Flask-Ask video <https://alexatutorial.com/1>`_ is available on
-`AlexaTutorial.com <https://alexatutorial.com>`_.
+📼 Here is a video demo on  `Handling Requests with Flask-Ask video <https://youtu.be/6RoSi3G1chk>`_.
 
 Flask-Ask has decorators to map Alexa requests to view functions.
 
@@ -74,8 +73,7 @@ Launch and intent requests can both start sessions. Avoid duplicate code with th
 Mapping Intent Slots to View Function Parameters
 ------------------------------------------------
 
-📼 An `Intent Slots with Flask-Ask video <https://alexatutorial.com/3>`_ is available on
-`AlexaTutorial.com <https://alexatutorial.com>`_.
+📼 Here is a video demo on `Intent Slots with Flask-Ask video <https://youtu.be/AnyZG2AJE4o>`_.
 
 
 When Parameter and Slot Names Differ
@@ -110,8 +108,7 @@ literal or a callable that resolves to a value. The next example shows the liter
 Converting Slots Values to Python Data Types
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-📼 A `Slot Conversions with Flask-Ask video <https://alexatutorial.com/4>`_ is available on
-`AlexaTutorial.com <https://alexatutorial.com>`_.
+📼 Here is a video demo on  `Slot Conversions with Flask-Ask video <https://youtu.be/gP86uugBico>`_.
 
 When slot values are available, they're always assigned to parameters as strings. Convert to other Python
 data types with ``convert``. ``convert`` is a ``dict`` that maps parameter names to callables::
@@ -130,8 +127,7 @@ inputs like those in Amazon's
 `documentation <https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interaction-model-reference#Slot%20Types>`_,
 just pass the strings in the second column below:
 
-📼 A `Slot Conversion Helpers with Flask-Ask video <https://alexatutorial.com/5>`_ is available on
-`AlexaTutorial.com <https://alexatutorial.com>`_.
+📼 Here is a video demo on  `Slot Conversion Helpers with Flask-Ask video <https://youtu.be/2RoRoABK_VE>`_.
 
 =================== =============== ======================
 Amazon Data Type    String          Python Data Type

--- a/docs/responses.rst
+++ b/docs/responses.rst
@@ -1,8 +1,7 @@
 Building Responses
 ==================
 
-📼 A `Building Responses with Flask-Ask video <https://alexatutorial.com/2>`_ is available on
-`AlexaTutorial.com <https://alexatutorial.com>`_.
+📼 Here is a video demo on `Building Responses with Flask-Ask video <https://youtu.be/mObuAlfxnl8>`_ .
 
 The two primary constructs in Flask-Ask for creating responses are ``statement`` and ``question``.
 


### PR DESCRIPTION
The AlexaTutorial.com site seems to be down, I found the videos on youtube and changed the URLs on the documentation.