### PR TITLE
Fix issue with slight nuance between io packages in PY2 and PY3.

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -3,7 +3,7 @@ import sys
 import yaml
 import inspect
 from datetime import datetime
-from io import BytesIO
+from io import StringIO
 from functools import wraps, partial
 
 import aniso8601
@@ -610,7 +610,7 @@ class Ask(object):
         body = json.dumps(event)
         environ['CONTENT_TYPE'] = 'application/json'
         environ['CONTENT_LENGTH'] = len(body)
-        environ['wsgi.input'] = BytesIO(body)
+        environ['wsgi.input'] = StringIO(body)
 
         # Start response is a required callback that must be passed when
         # the application is invoked. It is used to set HTTP status and

--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -2,8 +2,8 @@ import os
 import sys
 import yaml
 import inspect
+import io
 from datetime import datetime
-from io import StringIO
 from functools import wraps, partial
 
 import aniso8601
@@ -610,7 +610,13 @@ class Ask(object):
         body = json.dumps(event)
         environ['CONTENT_TYPE'] = 'application/json'
         environ['CONTENT_LENGTH'] = len(body)
-        environ['wsgi.input'] = StringIO(body)
+        
+        PY3 = sys.version_info[0] == 3
+        
+        if PY3:
+            environ['wsgi.input'] = io.StringIO(body)
+        else:
+            environ['wsgi.input'] = io.BytesIO(body)
 
         # Start response is a required callback that must be passed when
         # the application is invoked. It is used to set HTTP status and


### PR DESCRIPTION
While using AWS Lambda directly the change to `BytesIO` works fine for python2, but fails in python3. I am currently using this fork for using PY3 with Lambda. In python3 `BytesIO` is expecting a byte-like type and in python2 it can take a string. This fixes it for my use-case and leaves the current setup unchanged.