### PR TITLE
Add card for LinkAccount

### DIFF
--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -76,6 +76,14 @@ class _Response(object):
 
         self._response['card'] = card
         return self
+
+    def link_card(self):
+        card = {
+            'type': 'LinkAccount'
+        }
+
+        self._response['card'] = card
+        return self
     
     def list_display_render(self, template=None, title=None, backButton='HIDDEN', token=None, background_image_url=None, image=None, listItems=None, hintText=None):
         directive = [


### PR DESCRIPTION
This card only requires to specify the type tag as specified here: https://developer.amazon.com/docs/custom-skills/include-a-card-in-your-skills-response.html

Really useful for those of us wanting to use account linking! I tested it on my own Alexa skill and it is working like a charm.