### PR TITLE
Adds support for arrays in templates.yaml, chooses one at random

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -2,6 +2,7 @@ import os
 import sys
 import yaml
 import inspect
+import random
 from datetime import datetime
 from io import BytesIO
 from functools import wraps, partial
@@ -869,6 +870,12 @@ class YamlLoader(BaseLoader):
         if self.last_mtime != os.path.getmtime(self.path):
             self._reload_mapping()
         if template in self.mapping:
-            source = self.mapping[template]
+            # convert to template list if not already
+            # choose one at random
+            options = self.mapping[template]
+            if not isinstance(options, list):
+                options = [options]
+
+            source = random.choice(options)
             return source, None, lambda: source == self.mapping.get(template)
         raise TemplateNotFound(template)


### PR DESCRIPTION
I needed a way to support multiple responses and intent confirmations from my code rather than from the InteractionModel. This update allows you to use an array in the templates.yaml template file and it will choose one at random. Functionality for non-arrays is maintained.

Example template:

```
alexa_response:
  - Random Response 1 for {{ user }}
  - Random Response 2 for {{ user }}
```