### PR TITLE
Supporting UTF-8 in tempaltes.yaml (for French/German ...)

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -884,7 +884,7 @@ class YamlLoader(BaseLoader):
     def _reload_mapping(self):
         if os.path.isfile(self.path):
             self.last_mtime = os.path.getmtime(self.path)
-            with open(self.path) as f:
+            with open(self.path, encoding="utf-8") as f:
                 self.mapping = yaml.safe_load(f.read())
 
     def get_source(self, environment, template):


### PR DESCRIPTION
Currently, typing non ascii characters in templates.yaml yields unpredictable result, depending on the current OS locale .... 
This is of course not suitable for code as many devlopers working with a repo must use the same encoding. 

As it is the default for Flask tempaltes, I enforced "utf-8" for the templates.yaml files.