### PR TITLE
update pyyaml version to fix compile errors in py3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ aniso8601==1.2.0
 Flask==0.12.1
 cryptography==2.1.4
 pyOpenSSL==17.0.0
-PyYAML==3.12
+PyYAML==3.13
 six==1.11.0
 


### PR DESCRIPTION
pyyaml==3.12 version gives compile errors in python v3.7
it was fixed in pyyaml==3.13 

so i updated the pyyaml version in requirement file to support python latest version 3.7