### PR TITLE
allow consent_card to request multiple permissions

### DIFF
--- a/flask_ask/models.py
+++ b/flask_ask/models.py
@@ -158,9 +158,11 @@ class _Response(object):
         return self
 
     def consent_card(self, permissions):
+        if not isinstance(permissions, list):
+            permissions = [permissions]
         card = {
             'type': 'AskForPermissionsConsent',
-            'permissions': [permissions]
+            'permissions': permissions
         }
         self._response['card'] = card
         return self


### PR DESCRIPTION
The current consent card assumes one permission, allow a list of permissions to be passed.