### PR TITLE
allows ask.default_intent to route to the default intent as a catch a…

### DIFF
--- a/flask_ask/core.py
+++ b/flask_ask/core.py
@@ -802,7 +802,7 @@ class Ask(object):
                 result = self._session_ended_view_func()
             else:
                 result = "{}", 200
-        elif request_type == 'IntentRequest' and self._intent_view_funcs:
+        elif request_type == 'IntentRequest' and ( self._intent_view_funcs or self._default_intent_view_func is not None ):
             result = self._map_intent_to_view_func(self.request.intent)()
         elif request_type == 'Display.ElementSelected' and self._display_element_selected_func:
             result = self._display_element_selected_func()


### PR DESCRIPTION
…ll, without explicitly requiring an @ask.intent('just_here_put_to_something_in__intent_view_funcs') to be used as well.

currently works like
@ask.launch
@ask.intent('just_here_to_put_something_in__intent_view_funcs')
@ask.display_element_selected
@ask.default_intent
def catch_all():

pull request code allows

@ask.launch
@ask.display_element_selected
@ask.default_intent
def catch_all():
    
