### PR TITLE
updating the NOAA endpoint with HTTPS

### DIFF
--- a/samples/tidepooler/tidepooler.py
+++ b/samples/tidepooler/tidepooler.py
@@ -11,7 +11,7 @@ from flask import Flask, json, render_template
 from flask_ask import Ask, request, session, question, statement
 
 
-ENDPOINT = "http://tidesandcurrents.noaa.gov/api/datagetter"
+ENDPOINT = "https://tidesandcurrents.noaa.gov/api/datagetter"
 SESSION_CITY = "city"
 SESSION_DATE = "date"
 


### PR DESCRIPTION
Hi there,

We have a free program analysis tool for Python based web projects, called Bento. While we were scanning GitHub projects for issues, your project triggered a warning for unescaped Jinja templates.

In general, it is good practice to auto-escape parameters passed to `render_template()` method (https://flask.palletsprojects.com/en/1.1.x/templating/#jinja-setup). I was trying to figure out if any of the parameters (ex: samples/tidepooler/tidepooler.py:113) can be tainted to trigger an XSS. `cities` variable comes from the NOAA endpoint, which should be ok. But I thought converting the base URL to https would make it safer. Hopefully, you'll agree.

Bento flagged a few other issues including the debug mode flag for the Flask app, which is a known security issue in production (https://flask.palletsprojects.com/en/1.1.x/config/#DEBUG), and a potential buy in samples/purchase/purchase.py:52 `question_text` seems to be undefined in this context but I didn't update those to keep this PR simple. If you are curious, feel free download and give Bento a try (https://bento.dev).

