### PR TITLE
Updates for Python 3.x, Flask 3.x

### DIFF
--- a/flask_ask/convert.py
+++ b/flask_ask/convert.py
@@ -8,15 +8,15 @@ from . import logger
 
 _DATE_PATTERNS = {
     # "today", "tomorrow", "november twenty-fifth": 2015-11-25
-    '^\d{4}-\d{2}-\d{2}$': '%Y-%m-%d',
+    r'^\d{4}-\d{2}-\d{2}$': '%Y-%m-%d',
     # "this week", "next week": 2015-W48
-    '^\d{4}-W\d{2}$': '%Y-W%U-%w',
+    r'^\d{4}-W\d{2}$': '%Y-W%U-%w',
     # "this weekend": 2015-W48-WE
-    '^\d{4}-W\d{2}-WE$': '%Y-W%U-WE-%w',
+    r'^\d{4}-W\d{2}-WE$': '%Y-W%U-WE-%w',
     # "this month": 2015-11
-    '^\d{4}-\d{2}$': '%Y-%m',
+    r'^\d{4}-\d{2}$': '%Y-%m',
     # "next year": 2016
-    '^\d{4}$': '%Y',
+    r'^\d{4}$': '%Y',
 }
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
-mock==2.0.0
-requests==2.13.0
-tox==2.7.0
+mock==5.1.0
+requests==2.32.3
+tox==4.23.2
+urllib3==2.2.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-aniso8601==1.2.0
-Flask==1.1.1
-cryptography==2.1.4
-pyOpenSSL==17.0.0
-PyYAML==5.4
-six==1.11.0
-Werkzeug==0.16.1
+aniso8601==1.3.0
+Flask==3.1.0
+cryptography==43.0.3
+pyOpenSSL==24.2.1
+PyYAML==6.0.2
+six==1.16.0
+Werkzeug==3.1.3
+markupsafe==3.0.2
+cachelib==0.13.0

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,17 +1,20 @@
 import unittest
-from mock import patch, MagicMock
+from unittest.mock import patch
+from mock import MagicMock
 from flask import Flask
 from flask_ask import Ask, audio
 from flask_ask.models import _Field
 
+app = Flask(__name__)
 
 class AudioUnitTests(unittest.TestCase):
 
     def setUp(self):
-        self.ask_patcher = patch('flask_ask.core.find_ask', return_value=Ask())
-        self.ask_patcher.start()
-        self.context_patcher = patch('flask_ask.models.context', return_value=MagicMock())
-        self.context_patcher.start()
+        with app.app_context():
+            self.ask_patcher = patch('flask_ask.core.find_ask', return_value=Ask())
+            self.ask_patcher.start()
+            self.context_patcher = patch('flask_ask.models.context', return_value=MagicMock())
+            self.context_patcher.start()
 
     def tearDown(self):
         self.ask_patcher.stop()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
 import unittest
 from mock import patch, Mock
-from werkzeug.contrib.cache import SimpleCache
+from cachelib import SimpleCache
 from flask_ask.core import Ask
 from flask_ask.cache import push_stream, pop_stream, top_stream, set_stream
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,7 @@ import unittest
 from aniso8601.timezone import UTCOffset, build_utcoffset
 from flask_ask.core import Ask
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from mock import patch, MagicMock
 import json
 
@@ -58,7 +58,7 @@ class TestCoreRoutines(unittest.TestCase):
 
         # should cause a ValueError normally
         with self.assertRaises(ValueError):
-            datetime.utcfromtimestamp(max_timestamp)
+            datetime.fromtimestamp(max_timestamp, timezone.utc).replace(tzinfo=None)
 
         # should safely parse, assuming scale change needed
         # note: this assert looks odd, but Py2 handles the parsing


### PR DESCRIPTION
I recently used this library and wanted to use the latest version of Python and Flask, so I performed the syntax updates for Python 3.x and Flask 3.x. Tested on 3.11 / Flask 3.1.0. Updated the unit tests and ensured all passed. Thanks! 